### PR TITLE
Corrected livestream show flow

### DIFF
--- a/app/views/livestreams/_ajax-over-listener.html.erb
+++ b/app/views/livestreams/_ajax-over-listener.html.erb
@@ -7,7 +7,7 @@
     function check_status(){
       $.ajax({
           type: "GET",
-          url: "/livestreams/4/status",
+          url: "/livestreams/<%= @livestream.id %>/status",
           dataType: "json",
           success: function(status){
               if (status === false)


### PR DESCRIPTION
+ When livestreamer exits the livestream show page whilst streaming we assume that he is ending the stream and so set the stream to ended and display the stream ended message to viewers    